### PR TITLE
adding ipynb fle for building on colab

### DIFF
--- a/convert_llama.ipynb
+++ b/convert_llama.ipynb
@@ -1,0 +1,168 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "provenance": [],
+      "machine_shape": "hm"
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    },
+    "gpuClass": "standard",
+    "accelerator": "GPU"
+  },
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "T7yGGyiT-BiL"
+      },
+      "outputs": [],
+      "source": [
+        "!git clone https://github.com/qwopqwop200/GPTQ-for-LLaMa.git"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "#downloading all the 7B file using https://github.com/shawwn/llama-dl/blob/main/llama.sh\n",
+        "\n",
+        "%%bash\n",
+        "\n",
+        "PRESIGNED_URL=\"https://agi.gpt4.org/llama/LLaMA/*\"\n",
+        "\n",
+        "MODEL_SIZE=\"7B\"  # edit this list with the model sizes you wish to download\n",
+        "TARGET_FOLDER=\"./\"             # where all files should end up\n",
+        "\n",
+        "declare -A N_SHARD_DICT\n",
+        "\n",
+        "N_SHARD_DICT[\"7B\"]=\"0\"\n",
+        "N_SHARD_DICT[\"13B\"]=\"1\"\n",
+        "N_SHARD_DICT[\"30B\"]=\"3\"\n",
+        "N_SHARD_DICT[\"65B\"]=\"7\"\n",
+        "\n",
+        "echo \"Downloading tokenizer\"\n",
+        "wget ${PRESIGNED_URL/'*'/\"tokenizer.model\"} -O ${TARGET_FOLDER}\"/tokenizer.model\"\n",
+        "wget ${PRESIGNED_URL/'*'/\"tokenizer_checklist.chk\"} -O ${TARGET_FOLDER}\"/tokenizer_checklist.chk\"\n",
+        "\n",
+        "(cd ${TARGET_FOLDER} && md5sum -c tokenizer_checklist.chk)\n",
+        "\n",
+        "for i in ${MODEL_SIZE//,/ }\n",
+        "do\n",
+        "    echo \"Downloading ${i}\"\n",
+        "    mkdir -p ${TARGET_FOLDER}\"/${i}\"\n",
+        "    for s in $(seq -f \"0%g\" 0 ${N_SHARD_DICT[$i]})\n",
+        "    do\n",
+        "        wget ${PRESIGNED_URL/'*'/\"${i}/consolidated.${s}.pth\"} -O ${TARGET_FOLDER}\"/${i}/consolidated.${s}.pth\"\n",
+        "    done\n",
+        "    wget ${PRESIGNED_URL/'*'/\"${i}/params.json\"} -O ${TARGET_FOLDER}\"/${i}/params.json\"\n",
+        "    wget ${PRESIGNED_URL/'*'/\"${i}/checklist.chk\"} -O ${TARGET_FOLDER}\"/${i}/checklist.chk\"\n",
+        "    echo \"Checking checksums\"\n",
+        "    (cd ${TARGET_FOLDER}\"/${i}\" && md5sum -c checklist.chk)\n",
+        "done"
+      ],
+      "metadata": {
+        "id": "IPwL8yqYYVZf"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!mv 7B GPTQ-for-LLaMa/7B\n",
+        "%cd GPTQ-for-LLaMa"
+      ],
+      "metadata": {
+        "id": "YZoTgBsweE7I"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu117"
+      ],
+      "metadata": {
+        "id": "0mOfghitgj4_"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import torch\n",
+        "print(torch.__version__)"
+      ],
+      "metadata": {
+        "id": "tjybIED3gksc"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!pip install -r requirements.txt\n",
+        "!python3 setup_cuda.py install"
+      ],
+      "metadata": {
+        "id": "mHOGLalidoKg"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!pip install accelerate"
+      ],
+      "metadata": {
+        "id": "neubh15vidz0"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!python convert_llama_weights_to_hf.py --input_dir . --model_size 7B --output_dir ./output"
+      ],
+      "metadata": {
+        "id": "hqLB8rx1d8_s"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!CUDA_VISIBLE_DEVICES=0 python llama.py ./output/llama-7b ptb --wbits 4 --groupsize 128 --save_safetensors llama7b-4bit-128g.safetensors"
+      ],
+      "metadata": {
+        "id": "SiKQXei9jCsT"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!CUDA_VISIBLE_DEVICES=0 python llama_inference.py ./output/llama-7b --wbits 4 --groupsize 128 --load llama7b-4bit-128g.pt --text \"this is llama\""
+      ],
+      "metadata": {
+        "id": "5ixbUSVyoV1L"
+      },
+      "execution_count": null,
+      "outputs": []
+    }
+  ]
+}


### PR DESCRIPTION
Working at getting an example of building a quantized 7B file working on colab.
Seems useful to have to compile instructions for users and test new versions of pytorch / other dependencies quickly.
It's not currently working, and is giving

Traceback (most recent call last):
File "/content/GPTQ-for-LLaMa/llama.py", line 413, in
dataloader, testloader = get_loaders(
File "/content/GPTQ-for-LLaMa/datautils.py", line 109, in get_loaders
return get_ptb(nsamples, seed, seqlen, model)
File "/content/GPTQ-for-LLaMa/datautils.py", line 38, in get_ptb
tokenizer = AutoTokenizer.from_pretrained(model, use_fast=False)
File "/usr/local/lib/python3.9/dist-packages/transformers/models/auto/tokenization_auto.py", line 680, in from_pretrained
return tokenizer_class.from_pretrained(pretrained_model_name_or_path, *inputs, **kwargs)
File "/usr/local/lib/python3.9/dist-packages/transformers/tokenization_utils_base.py", line 1805, in from_pretrained
return cls._from_pretrained(
File "/usr/local/lib/python3.9/dist-packages/transformers/tokenization_utils_base.py", line 1959, in _from_pretrained
tokenizer = cls(*init_inputs, **init_kwargs)
File "/usr/local/lib/python3.9/dist-packages/transformers/models/llama/tokenization_llama.py", line 71, in init
self.sp_model.Load(vocab_file)
File "/usr/local/lib/python3.9/dist-packages/sentencepiece/init.py", line 905, in Load
return self.LoadFromFile(model_file)
File "/usr/local/lib/python3.9/dist-packages/sentencepiece/init.py", line 310, in LoadFromFile
return _sentencepiece.SentencePieceProcessor_LoadFromFile(self, arg)
TypeError: not a string

at !CUDA_VISIBLE_DEVICES=0 python llama.py ./output/llama-7b ptb --wbits 4 --groupsize 128 --save_safetensors llama7b-4bit-128g.safetensors

Trying to figure out why that's the case and fix it in the next commit. Suggesting this as a pr just in case you have any quick insight in the meanwhile.