### PR TITLE
Implement fallback to PyTorch matmul on large input sizes 

### DIFF
--- a/quant.py
+++ b/quant.py
@@ -156,6 +156,21 @@ class QuantLinear(nn.Module):
         self.half_indim = self.infeatures // 2
         self._initialized_quant_state = False
         self.faster = faster
+        # Buffers for bit shifting weight unpacking
+        if self.bits == 4:
+            self.register_buffer('wf1', torch.tensor([0, 4, 8, 12, 16, 20, 24, 28], dtype=torch.int32).unsqueeze(0).unsqueeze(2), persistent=False)
+            self.register_buffer('wf2', torch.tensor([0, 4, 8, 12, 16, 20, 24, 28], dtype=torch.int32).unsqueeze(0).unsqueeze(0), persistent=False)
+        elif self.bits == 3:
+            self.register_buffer('wf1', torch.tensor([
+                [0, 3, 6, 9, 12, 15, 18, 21, 24, 27, 30, 0],
+                [0, 1, 4, 7, 10, 13, 16, 19, 22, 25, 28, 31],
+                [0, 2, 5, 8, 11, 14, 17, 20, 23, 26, 29, 0],
+            ], dtype=torch.int32).reshape(1,3,12,1), persistent=False)
+            self.register_buffer('wf2', torch.tensor([
+                [0, 3, 6, 9, 12, 15, 18, 21, 24, 27, 30, 0],
+                [0, 1, 4, 7, 10, 13, 16, 19, 22, 25, 28, 31],
+                [0, 2, 5, 8, 11, 14, 17, 20, 23, 26, 29, 0],
+            ], dtype=torch.int32).reshape(1,1,3,12), persistent=False)
 
     def pack(self, linear, scales, zeros):
         scales = scales.t().contiguous()
@@ -252,6 +267,54 @@ class QuantLinear(nn.Module):
                 self.bias.data = self.bias.data.to(torch.float32)
             else:
                 self.bias = None
+
+        if x.shape[-2] >= 128 and self.bias == None:
+            # Fall back to PyTorch matmul
+            if self.bits == 4 :
+                # Unpack 4bit weights
+                weight = torch.bitwise_right_shift(torch.unsqueeze(self.qweight, 1).expand(-1, 8, -1), self.wf1).to(torch.int8)
+                torch.bitwise_and(weight, 0x0000000F, out=weight)
+                weight = weight.reshape(-1, self.groupsize, weight.shape[2])
+
+                zeros = torch.bitwise_right_shift(torch.unsqueeze(self.qzeros, 2).expand(-1, -1, 8), self.wf2).to(torch.int8)
+                torch.bitwise_and(zeros, 0x0000000F, out=zeros)
+                zeros = zeros + 1
+                zeros = zeros.reshape(-1, zeros.shape[1] * zeros.shape[2])
+
+                scales = self.scales
+
+                weights = (scales * (weight - zeros))
+                weights = weights.reshape(weights.shape[0] * weight.shape[1], weights.shape[2])
+                x = torch.matmul(x, weights.to(x.dtype))
+                return x
+            if self.bits == 3:
+                # Unpack 3bit weights
+
+                weight = self.qweight.reshape(self.qweight.shape[0]//3, 3, 1, self.qweight.shape[1]).expand(-1, -1, 12, -1)
+                weight = (weight >> self.wf1)&0x7
+                weight[:,0,10] = (weight[:,0,10]&0x3) | ((weight[:,1,0] << 2)&0x4)
+                weight[:,1,11] = (weight[:,1,11]&0x1) | ((weight[:,2,0] << 1)&0x6)
+                weight = weight & 0x7
+                weight = torch.cat([weight[:,0,:11], weight[:,1,1:12], weight[:,2,1:11]], dim=1)
+                weight = weight.reshape(-1, self.groupsize, weight.shape[2])
+
+                zeros = self.qzeros.reshape(self.qzeros.shape[0], self.qzeros.shape[1]//3, 3, 1).expand(-1, -1, -1, 12)
+                zeros = (zeros >> self.wf2)
+                zeros[:,:,0,10] = (zeros[:,:,0,10]&0x3) | ((zeros[:,:,1,0] << 2)&0x4)
+                zeros[:,:,1,11] = (zeros[:,:,1,11]&0x1) | ((zeros[:,:,2,0] << 1)&0x6)
+                zeros = zeros & 0x7
+                zeros = torch.cat([zeros[:,:,0,:11], zeros[:,:,1,1:12], zeros[:,:,2,1:11]], dim=2)
+                zeros = zeros.reshape(-1, 1, zeros.shape[1] * zeros.shape[2])
+                zeros = zeros + 1
+
+                scales = self.scales
+                scales = scales.reshape(-1, 1, scales.shape[-1])
+
+                weights = (scales * (weight - zeros))
+                weights = weights.reshape(weights.shape[0] * weight.shape[1], weights.shape[2])
+                x = torch.matmul(x, weights.to(x.dtype))
+
+                return x
 
         outshape = list(x.shape)
         outshape[-1] = self.outfeatures

--- a/quant.py
+++ b/quant.py
@@ -368,7 +368,7 @@ class QuantLinear(nn.Module):
         y = y.to(output_dtype)
         return y.reshape(outshape)
 
-def make_quant(module, names, bits, groupsize, faster=False, name='', kernel_switch_threshold=False):
+def make_quant(module, names, bits, groupsize, faster=False, name='', kernel_switch_threshold=128):
     if isinstance(module, QuantLinear):
         return
     for attr in dir(module):

--- a/quant.py
+++ b/quant.py
@@ -136,7 +136,7 @@ except:
 
 # Assumes layer is perfectly divisible into 256 * 256 blocks
 class QuantLinear(nn.Module): 
-    def __init__(self, bits, groupsize, infeatures, outfeatures, faster=False, kernel_switch_threshold=None):
+    def __init__(self, bits, groupsize, infeatures, outfeatures, faster=False, kernel_switch_threshold=128):
         super().__init__()
         if bits not in [2,3,4,8]:
             raise NotImplementedError("Only 2,3,4,8 bits are supported.")

--- a/quant.py
+++ b/quant.py
@@ -279,9 +279,10 @@ class QuantLinear(nn.Module):
                 zeros = torch.bitwise_right_shift(torch.unsqueeze(self.qzeros, 2).expand(-1, -1, 8), self.wf2).to(torch.int8)
                 torch.bitwise_and(zeros, 0x0000000F, out=zeros)
                 zeros = zeros + 1
-                zeros = zeros.reshape(-1, zeros.shape[1] * zeros.shape[2])
+                zeros = zeros.reshape(-1, 1, zeros.shape[1] * zeros.shape[2])
 
                 scales = self.scales
+                scales = scales.reshape(-1, 1, scales.shape[-1])
 
                 weights = (scales * (weight - zeros))
                 weights = weights.reshape(weights.shape[0] * weight.shape[1], weights.shape[2])


### PR DESCRIPTION
Modifies QuantLinear to use PyTorch matmul when input size is sufficiently large. The quantized weights are unpacked in the forward pass and `torch.matmul` is used. Adds `kernel_switch_threshold` parameter to `make_quant` and `QuantLinear`. This parameter controls the cutoff input size after which the behavior triggers, and defaults to 128. By setting `kernel_switch_threshold=False` or to some very large number, the behavior can be disabled.

Only supports 3-bit and 4-bit weights at the moment. In addition, very slow CPU inference is possible by disabling the quantized matmul CUDA kernels entirely by setting `kernel_switch_threshold=0`.

#82 