### PR TITLE
Make sure to save the quantized model before bench/eval

### DIFF
--- a/llama.py
+++ b/llama.py
@@ -449,6 +449,15 @@ if __name__ == '__main__':
         quantizers = llama_sequential(model, dataloader, DEV)
         print(time.time() - tick)
 
+    if args.save:
+        llama_pack(model, quantizers, args.wbits, args.groupsize)
+        torch.save(model.state_dict(), args.save) 
+
+    if args.save_safetensors:
+        llama_pack(model, quantizers, args.wbits, args.groupsize)
+        from safetensors.torch import save_file as safe_save
+        safe_save(model.state_dict(), args.save_safetensors)
+        
     if args.benchmark:
         gpus = [torch.device('cuda:%d' % i) for i in range(torch.cuda.device_count())]
         if len(gpus) > 1:
@@ -471,11 +480,4 @@ if __name__ == '__main__':
         print(dataset)
         llama_eval(model, testloader, DEV)
 
-    if args.save:
-        llama_pack(model, quantizers, args.wbits, args.groupsize)
-        torch.save(model.state_dict(), args.save) 
-
-    if args.save_safetensors:
-        llama_pack(model, quantizers, args.wbits, args.groupsize)
-        from safetensors.torch import save_file as safe_save
-        safe_save(model.state_dict(), args.save_safetensors)
+  


### PR DESCRIPTION
Depending on the configuration of the quantization parameters and GPU hardware, it can take several hours to fully quantize the model. 

Unfortunately, benchmarking and model evaluation may increase vram usage and cause oom.
 
To prevent losing all the hard work, gone in a snap, followed by palm-to-face and coffee-in-our-lap moments, we must prioritize saving the quantized models over everything else.