### PR TITLE
patch to work with triton-2.0 on low mem devices

### DIFF
--- a/custom_autotune.py
+++ b/custom_autotune.py
@@ -68,9 +68,9 @@ class Autotuner(triton.KernelInterface):
 		try:
 			# In testings using only 40 reps seems to be close enough and it appears to be what PyTorch uses
 			# PyTorch also sets fast_flush to True, but I didn't see any speedup so I'll leave the default
-			return triton.testing.do_bench(kernel_call, rep=40)
+			return triton.testing.do_bench(kernel_call, percentiles=(0.5, 0.2, 0.8), rep=40)
 		except triton.compiler.OutOfResources:
-			return float('inf')
+			return (float('inf'), float('inf'), float('inf'))	
 
 	def run(self, *args, **kwargs):
 		self.nargs = dict(zip(self.arg_names, args))


### PR DESCRIPTION
Issue described here https://github.com/openai/triton/pull/1208

This patch will allow benchmark to work on lower memory devices with triton-2.0.  

Also described here...

https://github.com/qwopqwop200/GPTQ-for-LLaMa/issues/129

