### PR TITLE
Fix multigpu inference.

### DIFF
--- a/llama.py
+++ b/llama.py
@@ -289,9 +289,15 @@ def llama_multigpu(model, gpus):
             inp = list(inp)
             if inp[0].device != self.dev:
                 inp[0] = inp[0].to(self.dev)
-            if cache['mask'] is None or cache['mask'].device != self.dev:
-                cache['mask'] = kwargs['attention_mask'].to(self.dev)
-            kwargs['attention_mask'] = cache['mask']
+            # if cache['mask'] is None or cache['mask'].device != self.dev:
+            #     cache['mask'] = kwargs['attention_mask'].to(self.dev)
+            # kwargs['attention_mask'] = cache['mask']
+            for k, v in kwargs.items():
+                try:
+                    if v.device != self.dev:
+                        kwargs[k] = v.to(self.dev)
+                except AttributeError:
+                    pass
             tmp = self.module(*inp, **kwargs)
             return tmp
 
@@ -299,6 +305,28 @@ def llama_multigpu(model, gpus):
     pergpu = math.ceil(len(layers) / len(gpus))
     for i in range(len(layers)):
         layers[i] = MoveModule(layers[i].to(gpus[i // pergpu]))
+
+    # gather output back to cuda:0
+    old_forward = model.forward
+    def forward(*args, **kargs):
+        output = old_forward(*args, **kargs)
+        if isinstance(output, dict):
+            for k, v in output.items():
+                try:
+                    output[k] = v.to(0)
+                except AttributeError:
+                    pass
+        else:   # tuple
+            outputs = []
+            for v in output:
+                try:
+                    outputs.append(v.to(0))
+                except AttributeError:
+                    outputs.append(v)
+            output = tuple(outputs)
+        return output
+    
+    model.forward = forward
 
     model.gpus = gpus
 

--- a/quant.py
+++ b/quant.py
@@ -374,29 +374,31 @@ except:
     print('trioton not installed.')
 
 def matmul248(input, qweight, scales, qzeros, g_idx, bits, maxq):
-    output = torch.empty((input.shape[0], qweight.shape[1]), device=input.device, dtype=torch.float16)
-    grid = lambda META: (triton.cdiv(input.shape[0], META['BLOCK_SIZE_M']) * triton.cdiv(qweight.shape[1], META['BLOCK_SIZE_N']),)
-    matmul_248_kernel[grid](input, qweight, output,
-                            scales, qzeros, g_idx,
-                            input.shape[0], qweight.shape[1], input.shape[1], bits, maxq,
-                            input.stride(0), input.stride(1),
-                            qweight.stride(0), qweight.stride(1),
-                            output.stride(0), output.stride(1),
-                            scales.stride(0), qzeros.stride(0))
-    return output
+    with torch.cuda.device(input.device):
+        output = torch.empty((input.shape[0], qweight.shape[1]), device='cuda', dtype=torch.float16)
+        grid = lambda META: (triton.cdiv(input.shape[0], META['BLOCK_SIZE_M']) * triton.cdiv(qweight.shape[1], META['BLOCK_SIZE_N']),)
+        matmul_248_kernel[grid](input, qweight, output,
+                                scales, qzeros, g_idx,
+                                input.shape[0], qweight.shape[1], input.shape[1], bits, maxq,
+                                input.stride(0), input.stride(1),
+                                qweight.stride(0), qweight.stride(1),
+                                output.stride(0), output.stride(1),
+                                scales.stride(0), qzeros.stride(0))
+        return output
 
 def transpose_matmul248(input, qweight, scales, qzeros, g_idx, bits, maxq):
-    output_dim = (qweight.shape[0] * 32) // bits
-    output = torch.empty((input.shape[0], output_dim), device=input.device, dtype=torch.float16)
-    grid = lambda META: (triton.cdiv(input.shape[0], META['BLOCK_SIZE_M']) * triton.cdiv(output_dim, META['BLOCK_SIZE_K']),)
-    transpose_matmul_248_kernel[grid](input, qweight, output,
-                                      scales, qzeros, g_idx,
-                                      input.shape[0], qweight.shape[1], output_dim, bits, maxq,
-                                      input.stride(0), input.stride(1),
-                                      qweight.stride(0), qweight.stride(1),
-                                      output.stride(0), output.stride(1),
-                                      scales.stride(0), qzeros.stride(0))
-    return output
+    with torch.cuda.device(input.device):
+        output_dim = (qweight.shape[0] * 32) // bits
+        output = torch.empty((input.shape[0], output_dim), device='cuda', dtype=torch.float16)
+        grid = lambda META: (triton.cdiv(input.shape[0], META['BLOCK_SIZE_M']) * triton.cdiv(output_dim, META['BLOCK_SIZE_K']),)
+        transpose_matmul_248_kernel[grid](input, qweight, output,
+                                        scales, qzeros, g_idx,
+                                        input.shape[0], qweight.shape[1], output_dim, bits, maxq,
+                                        input.stride(0), input.stride(1),
+                                        qweight.stride(0), qweight.stride(1),
+                                        output.stride(0), output.stride(1),
+                                        scales.stride(0), qzeros.stride(0))
+        return output
 
 class QuantLinearFunction(torch.autograd.Function):
     @staticmethod

--- a/quant.py
+++ b/quant.py
@@ -374,7 +374,7 @@ except:
     print('trioton not installed.')
 
 def matmul248(input, qweight, scales, qzeros, g_idx, bits, maxq):
-    output = torch.empty((input.shape[0], qweight.shape[1]), device='cuda', dtype=torch.float16)
+    output = torch.empty((input.shape[0], qweight.shape[1]), device=input.device, dtype=torch.float16)
     grid = lambda META: (triton.cdiv(input.shape[0], META['BLOCK_SIZE_M']) * triton.cdiv(qweight.shape[1], META['BLOCK_SIZE_N']),)
     matmul_248_kernel[grid](input, qweight, output,
                             scales, qzeros, g_idx,
@@ -387,7 +387,7 @@ def matmul248(input, qweight, scales, qzeros, g_idx, bits, maxq):
 
 def transpose_matmul248(input, qweight, scales, qzeros, g_idx, bits, maxq):
     output_dim = (qweight.shape[0] * 32) // bits
-    output = torch.empty((input.shape[0], output_dim), device='cuda', dtype=torch.float16)
+    output = torch.empty((input.shape[0], output_dim), device=input.device, dtype=torch.float16)
     grid = lambda META: (triton.cdiv(input.shape[0], META['BLOCK_SIZE_M']) * triton.cdiv(output_dim, META['BLOCK_SIZE_K']),)
     transpose_matmul_248_kernel[grid](input, qweight, output,
                                       scales, qzeros, g_idx,


### PR DESCRIPTION
Currently the triton multigpu is not working:
1. I find the output of `QuantLinear` is always on `cuda:0`. The edits to `quant.py` should fix this by placing the output on the same device as the input.
2. `MoveModule` is not moving keyword arguments to device. This should be fixed now.
3. The attention mask caching is not working correctly as in subsequent generations it is not invalidated, resulting in `model.generate()` only generate 1 token (tested on 1 gpu). I disabled the caching for the time being. Might be able to invalidate the caching before each `forward` in the following modified `forward` but it could introduce other bugs.
4. `model.forward()` should be working now but not `model.generate()`, as `generate()` needs to gather logits and scores back to the same gpu. I gather them in the modified `forward` to `cuda:0`.
5. Then it reports
```
Traceback (most recent call last):
  File "/home/sgsdxzy/Programs/text-generation-webui/modules/callbacks.py", line 66, in gentask
    ret = self.mfunc(callback=_callback, **self.kwargs)
  File "/home/sgsdxzy/Programs/text-generation-webui/modules/text_generation.py", line 245, in generate_with_callback
    shared.model.generate(**kwargs)
  File "/home/sgsdxzy/mambaforge/envs/textgen/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
  File "/home/sgsdxzy/mambaforge/envs/textgen/lib/python3.10/site-packages/transformers/generation/utils.py", line 1485, in generate
    return self.sample(
  File "/home/sgsdxzy/mambaforge/envs/textgen/lib/python3.10/site-packages/transformers/generation/utils.py", line 2560, in sample
    next_tokens = torch.multinomial(probs, num_samples=1).squeeze(1)
RuntimeError: probability tensor contains either `inf`, `nan` or element < 0
```
And it seems the output of `forward` is all `nan`. I cannot figure out why, help is needed.

Current state: apply `llama_multigpu` to a single gpu works correctly, but multiple gpus are still not working because of `nan`.


Resolves #135 