### PR TITLE
fix(gptq.py): index out of bounds

### DIFF
--- a/gptq.py
+++ b/gptq.py
@@ -114,7 +114,10 @@ class GPTQ:
 
                 if groupsize != -1:
                     if (i1 + i) % groupsize == 0:
-                        self.quantizer.find_params(W[:, (i1 + i):(i1 + i + groupsize)], weight=True)
+                        start = i1 + i
+                        end = start + groupsize
+                        if end < W.shape[-1]:
+                            self.quantizer.find_params(W[:, start:end], weight=True)
 
                     if ((i1 + i) // groupsize) - now_idx == -1:
                         scale.append(self.quantizer.scale)


### PR DESCRIPTION
I am reading your code, maybe.. there is an index out of bounds error.

For example:
1. `W.shape = [4096, 4096]`, blocksize=128, self.columns=4086, groupsize=128
2. in last loop, i1 =  4096-128
3. count=128, so i=127
4. (i1 + i + groupsize) =  4096 + 127,  bigger than W.shape[-1].

Tried with `pdb`.
 
As  a newcomer for GPT quantization, I am not sure how to fix it. Hope it helps.  @qwopqwop200 