### PR TITLE
fix(llama_inference.py): parameter error

### DIFF
--- a/llama_inference.py
+++ b/llama_inference.py
@@ -126,7 +126,7 @@ if __name__ == '__main__':
         args.load = args.load.as_posix()
     
     if args.load:
-        model = load_quant(args.model, args.load, args.wbits, args.groupsize, args.device)
+        model = load_quant(args.model, args.load, args.wbits, args.groupsize)
     else:
         model = get_llama(args.model)
         model.eval()


### PR DESCRIPTION
bugfix.

function declaration
```
def load_quant(model, checkpoint, wbits, groupsize = -1, fused_mlp = True ..):
```

function call
```
model = load_quant(args.model, args.load, args.wbits, args.groupsize, args.device)
```

`args.device==fused_mlp`  error.