### PR TITLE
explicitly declare wbits and group_size

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,10 +119,10 @@ CUDA_VISIBLE_DEVICES=0 python llama.py ${MODEL_DIR} c4 --wbits 4 --groupsize 128
 CUDA_VISIBLE_DEVICES=0,1,2,3,4 python llama.py ${MODEL_DIR} c4 --benchmark 2048 --check
 
 # model inference with the saved model
-CUDA_VISIBLE_DEVICES=7 python llama_inference.py ${MODEL_DIR} --load llama7b-4bit-128g.pt --text "this is llama"
+CUDA_VISIBLE_DEVICES=7 python llama_inference.py ${MODEL_DIR} --wbits 4 --groupsize 128 --load llama7b-4bit-128g.pt --text "this is llama"
 
 # model inference with the saved model using safetensors loaded direct to gpu
-CUDA_VISIBLE_DEVICES=0 python llama_inference.py ${MODEL_DIR} --load llama7b-4bit-128g.safetensors --text "this is llama" --device=0
+CUDA_VISIBLE_DEVICES=0 python llama_inference.py ${MODEL_DIR} --wbits 4 --groupsize 128 --load llama7b-4bit-128g.safetensors --text "this is llama" --device=0
 
 # model inference with the saved model with offload(This is very slow. This is a simple implementation and could be improved with technologies like flexgen(https://github.com/FMInference/FlexGen).
 CUDA_VISIBLE_DEVICES=0 python llama_inference_offload.py ${MODEL_DIR} --wbits 4 --groupsize 128 --load llama7b-4bit-128g.pt --text "this is llama" --pre_layer 16


### PR DESCRIPTION
if you are using llama7b-4bit-128g.pt, you should explicitly declare wbits and group_size instead of using the default params