### PR TITLE
Multi-GPU, allocate output tensor on input tensor's device

### DIFF
--- a/quant/fused_mlp.py
+++ b/quant/fused_mlp.py
@@ -209,7 +209,7 @@ class QuantLlamaMLP(nn.Module):
             x = x.reshape(-1, x.shape[-1])
             M, K = x.shape
             N = self.intermediate_size
-            c = torch.empty((M, N), device='cuda', dtype=torch.float16)
+            c = torch.empty((M, N), device=x.device, dtype=torch.float16)
             grid = lambda META: (triton.cdiv(M, META['BLOCK_SIZE_M']) * triton.cdiv(N, META['BLOCK_SIZE_N']), )
             fusedmatmul_248_kernel[grid](x, c, self.gate_proj_qweight, self.gate_proj_scales, self.gate_proj_qzeros, self.gate_proj_g_idx, self.up_proj_qweight, self.up_proj_scales,
                                          self.up_proj_qzeros, self.up_proj_g_idx, M, N, K, self.bits, self.maxq, x.stride(0), x.stride(1), self.gate_proj_qweight.stride(0),

--- a/quant/quant_linear.py
+++ b/quant/quant_linear.py
@@ -262,7 +262,7 @@ except:
 
 def matmul248(input, qweight, scales, qzeros, g_idx, bits, maxq):
     with torch.cuda.device(input.device):
-        output = torch.empty((input.shape[0], qweight.shape[1]), device='cuda', dtype=torch.float16)
+        output = torch.empty((input.shape[0], qweight.shape[1]), device=input.device, dtype=torch.float16)
         grid = lambda META: (triton.cdiv(input.shape[0], META['BLOCK_SIZE_M']) * triton.cdiv(qweight.shape[1], META['BLOCK_SIZE_N']), )
         matmul_248_kernel[grid](input, qweight, output, scales, qzeros, g_idx, input.shape[0], qweight.shape[1], input.shape[1], bits, maxq, input.stride(0), input.stride(1), qweight.stride(0),
                                 qweight.stride(1), output.stride(0), output.stride(1), scales.stride(0), qzeros.stride(0))
@@ -272,7 +272,7 @@ def matmul248(input, qweight, scales, qzeros, g_idx, bits, maxq):
 def transpose_matmul248(input, qweight, scales, qzeros, g_idx, bits, maxq):
     with torch.cuda.device(input.device):
         output_dim = (qweight.shape[0] * 32) // bits
-        output = torch.empty((input.shape[0], output_dim), device='cuda', dtype=torch.float16)
+        output = torch.empty((input.shape[0], output_dim), device=input.device, dtype=torch.float16)
         grid = lambda META: (triton.cdiv(input.shape[0], META['BLOCK_SIZE_M']) * triton.cdiv(output_dim, META['BLOCK_SIZE_K']), )
         transpose_matmul_248_kernel[grid](input, qweight, output, scales, qzeros, g_idx, input.shape[0], qweight.shape[1], output_dim, bits, maxq, input.stride(0), input.stride(1), qweight.stride(0),
                                           qweight.stride(1), output.stride(0), output.stride(1), scales.stride(0), qzeros.stride(0))


### PR DESCRIPTION
Prior to this commit, `QuantLinear` and `QuantLlamaMLP` would allocate their output tensor on `device="cuda"`.  This defaults to the first GPU, equivalent to `"cuda:0"`, rather than the currently active GPU. This commit updates the allocation of output tensors to instead occur on `device=input.device`.

This is required for multi-GPU execution on systems with separate memory spaces for each GPU (i.e. without NVLink).