### PR TITLE
Add -O3 flag to nvcc

### DIFF
--- a/setup_cuda.py
+++ b/setup_cuda.py
@@ -4,7 +4,8 @@ from torch.utils import cpp_extension
 setup(
     name='quant_cuda',
     ext_modules=[cpp_extension.CUDAExtension(
-        'quant_cuda', ['quant_cuda.cpp', 'quant_cuda_kernel.cu']
+        'quant_cuda', ['quant_cuda.cpp', 'quant_cuda_kernel.cu'],
+        extra_compile_args={'nvcc': ['-O3']}
     )],
     cmdclass={'build_ext': cpp_extension.BuildExtension}
 )


### PR DESCRIPTION
I noticed that nvcc isn't being configured to compile with any configuration options. I've added -O3 as a start.

I've noticed a gain from ~ 42 T / s to ~ 47 T / s running this model:
[https://huggingface.co/TheBloke/wizard-vicuna-13B-GPTQ](url)
on a RTX 3090

I invite others to test different nvcc optimization options to see if better performance can be achieved.