### PR TITLE
fused mlp is sometimes not working with safetensors, add an argument for it

### DIFF
--- a/llama_inference.py
+++ b/llama_inference.py
@@ -96,8 +96,11 @@ if __name__ == '__main__':
 
     parser.add_argument('--device', type=int, default=-1, help='The device used to load the model when using safetensors. Default device is "cpu" or specify, 0,1,2,3,... for GPU device.')
 
-    # fused mlp is not supported for safetensors
-    parser.add_argument('--fused_mlp', action='store_true', help='Use fused mlp for quantization.', default=True)
+    # fused mlp is sometimes not working with safetensors, no_fused_mlp is used to set fused_mlp to False, default is true
+    parser.add_argument('--fused_mlp', action='store_true')
+    parser.add_argument('--no_fused_mlp', dest='fused_mlp', action='store_false')
+    parser.set_defaults(fused_mlp=True)
+
     args = parser.parse_args()
 
     if type(args.load) is not str:

--- a/llama_inference.py
+++ b/llama_inference.py
@@ -96,13 +96,15 @@ if __name__ == '__main__':
 
     parser.add_argument('--device', type=int, default=-1, help='The device used to load the model when using safetensors. Default device is "cpu" or specify, 0,1,2,3,... for GPU device.')
 
+    # fused mlp is not supported for safetensors
+    parser.add_argument('--fused_mlp', action='store_true', help='Use fused mlp for quantization.', default=True)
     args = parser.parse_args()
 
     if type(args.load) is not str:
         args.load = args.load.as_posix()
 
     if args.load:
-        model = load_quant(args.model, args.load, args.wbits, args.groupsize)
+        model = load_quant(args.model, args.load, args.wbits, args.groupsize, fused_mlp=args.fused_mlp)
     else:
         model = get_llama(args.model)
         model.eval()


### PR DESCRIPTION
fused mlp is sometimes not working with safetensors, no_fused_mlp is used to set fused_mlp to False, default is true

I have had the same issues as some others:
https://github.com/qwopqwop200/GPTQ-for-LLaMa/issues/243